### PR TITLE
fixed package-lock.json

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -6087,7 +6087,7 @@
         "css-what": "^6.0.1",
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
+        "nth-check": ">=^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"


### PR DESCRIPTION
there is a security error for "nth-check" : "^2.0.1" stating it needs to updated to a higher version.  Offers adding ">=2.0.1" in the dependencies area, but I did this and still isn't correcting.